### PR TITLE
Refine conversation memory features and add /remember command

### DIFF
--- a/chatbot/chatbot_app.py
+++ b/chatbot/chatbot_app.py
@@ -72,6 +72,8 @@ class ChatbotApp:
                 self.console.print("[bold red]Usage: /switch [id][/bold red]")
         elif cmd == '/export':
             self.export_session(args[0] if args else "md")
+        elif cmd == '/remember':
+            self.handle_remember_command(command)
         elif cmd == '/mem':
             self.handle_memory_command(args)
         elif cmd == '/help':
@@ -248,6 +250,7 @@ class ChatbotApp:
             "/new": "Start a new chat session.",
             "/list": "List all available sessions.",
             "/switch [id]": "Switch to a specific session by its ID.",
+            "/remember [text]": "Tell the chatbot to remember a specific piece of information.",
             "/export [md|json]": "Export the current session to a file.",
             "/mem list": "List all stored long-term memories.",
             "/mem add \"cat\" \"shell\" \"details\"": "Manually add a new memory.",
@@ -261,6 +264,44 @@ class ChatbotApp:
             table.add_row(cmd, desc)
 
         self.console.print(table)
+
+    def handle_remember_command(self, user_input: str):
+        """Handles the /remember command to explicitly store a memory."""
+        # The command is '/remember', so the text is everything after that
+        details_to_remember = user_input.partition(' ')[2].strip()
+
+        if not details_to_remember:
+            self.console.print("[bold red]Usage: /remember [text to remember][/bold red]")
+            return
+
+        with self.console.status("[bold blue]Categorizing and storing memory...[/bold blue]"):
+            try:
+                # Use the AI to generate a category and shell
+                memory_structure = self.gemini_client.categorize_memory(details_to_remember)
+
+                if memory_structure and all(k in memory_structure for k in ["category", "shell"]):
+                    self.memory_manager.add_memory(
+                        memory_structure["category"],
+                        memory_structure["shell"],
+                        details_to_remember
+                    )
+                    mem_panel = Panel(
+                        f"[bold magenta]Category:[/bold magenta] {memory_structure['category']}\n"
+                        f"[bold yellow]Shell:[/bold yellow] {memory_structure['shell']}\n"
+                        f"[bold green]Details:[/bold green] {details_to_remember}",
+                        title="[bold blue]📝 Memory Stored[/bold blue]",
+                        border_style="blue"
+                    )
+                    self.console.print(mem_panel)
+                else:
+                    # Fallback if the AI fails to structure the data
+                    self.console.print("[bold red]Failed to categorize memory automatically. Storing without category.[/bold red]")
+                    self.memory_manager.add_memory("Uncategorized", "User Directed", details_to_remember)
+
+            except Exception as e:
+                self.console.print(f"[bold red]An error occurred while storing the memory: {e}[/bold red]")
+                self.memory_manager.add_memory("Uncategorized", "User Directed (Error)", details_to_remember)
+
 
     def handle_memory_command(self, args: list):
         """Handles memory management subcommands."""

--- a/chatbot/gemini_client.py
+++ b/chatbot/gemini_client.py
@@ -67,6 +67,35 @@ class GeminiClient:
         response = self.model.generate_content(prompt)
         return response.text.strip()
 
+    def categorize_memory(self, details: str) -> dict | None:
+        """
+        Uses the AI to determine a category and shell for a given piece of information.
+
+        Args:
+            details (str): The text content of the memory to categorize.
+
+        Returns:
+            dict | None: A dictionary with "category" and "shell" keys, or None on failure.
+        """
+        import json
+        system_prompt = """
+        You are a memory categorization assistant. Given a piece of text, your job is to determine a suitable "category" and "shell" for it.
+        - "category": A broad topic (e.g., "User Preferences", "Project Ideas", "Personal Details").
+        - "shell": A mid-level summary of the information (e.g., "Favorite Subjects", "Book Recommendations").
+        Please respond with ONLY a valid JSON object containing these two keys. Example: {"category": "User Preferences", "shell": "Favorite Colors"}
+        """
+
+        prompt = f"{system_prompt}\n\nText to categorize:\n{details}"
+
+        response = self.model.generate_content(prompt)
+
+        try:
+            # The response should be a JSON string, so we parse it.
+            return json.loads(response.text)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+
 if __name__ == '__main__':
     # Example usage (requires a .env file with GEMINI_API_KEY)
     try:

--- a/chatbot/memory_manager.py
+++ b/chatbot/memory_manager.py
@@ -129,7 +129,7 @@ class MemoryManager:
 
         system_prompt = """
         Your task is to analyze a conversation and identify facts, preferences, or key information that should be saved to a long-term memory.
-        The user may also explicitly ask to remember something.
+        Pay close attention to explicit instructions. If the user says "remember that...", "don't forget...", or similar phrases, you MUST treat this as a directive to store the information.
         If you find something worth remembering, extract it and format it as a JSON object with three keys: "category", "shell", and "details".
         - "category": A broad topic (e.g., "User Preferences", "Project Ideas", "Personal Details").
         - "shell": A mid-level summary of the information (e.g., "Favorite Subjects", "Book Recommendations").

--- a/chatbot/session_manager.py
+++ b/chatbot/session_manager.py
@@ -51,18 +51,36 @@ class SessionManager:
         )
 
         messages = cursor.fetchall()
-
-        # Simple token counting and truncation
-        # A more advanced implementation would use a proper tokenizer
         history = []
         current_tokens = 0
 
-        # Always include the most recent messages
+        # A common heuristic is ~4 characters per token
+        def count_tokens(text: str) -> int:
+            return len(text) // 4
+
+        # Handle the special case of injected memory prompt
+        system_prompt_messages = []
+        if len(messages) >= 2 and "I have some long-term memories" in messages[0]['content']:
+            system_prompt_user = messages[0]
+            system_prompt_model = messages[1]
+            system_prompt_messages = [
+                {"role": system_prompt_user["role"], "parts": [system_prompt_user["content"]]},
+                {"role": system_prompt_model["role"], "parts": [system_prompt_model["content"]]}
+            ]
+            prompt_tokens = count_tokens(system_prompt_user["content"]) + count_tokens(system_prompt_model["content"])
+
+            # If the prompt itself exceeds the limit, we can't do much
+            if prompt_tokens > max_tokens:
+                return []
+
+            current_tokens += prompt_tokens
+            messages = messages[2:] # Process the rest of the messages
+
+        # Process messages from newest to oldest
         temp_history = []
         for row in reversed(messages):
             content = row["content"]
-            # A common heuristic is ~4 characters per token
-            message_tokens = len(content) // 4
+            message_tokens = count_tokens(content)
 
             if current_tokens + message_tokens > max_tokens:
                 break
@@ -73,13 +91,9 @@ class SessionManager:
         # The history is reversed, so we reverse it back
         history = list(reversed(temp_history))
 
-        # This logic ensures that if a system prompt for memory was injected, it is preserved
-        # It assumes the first two messages are the system prompt and the model's ack.
-        if len(messages) > len(history) and "I have some long-term memories" in messages[0]['content']:
-             # check if the first message is not in history
-            if not any(msg['parts'][0] == messages[0]['content'] for msg in history):
-                history.insert(0, {"role": messages[1]["role"], "parts": [messages[1]["content"]]})
-                history.insert(0, {"role": messages[0]["role"], "parts": [messages[0]["content"]]})
+        # Prepend the system prompt messages if they exist
+        if system_prompt_messages:
+            history = system_prompt_messages + history
 
         return history
 


### PR DESCRIPTION
This commit introduces several improvements to the existing conversation memory system.

1.  **Fix History Truncation:** A bug in `session_manager.py` that could cause the conversation history to exceed the `max_tokens` limit when a memory prompt was injected has been fixed. The logic now correctly accounts for the prompt's size before processing the remaining history.

2.  **Add /remember Command:** A new user-facing command, `/remember <text>`, has been added. This allows users to explicitly and easily save a piece of information to the long-term memory. The command uses the AI to automatically categorize the memory and provides clear feedback to the user.

3.  **Improve Memory Analysis Prompt:** The system prompt for the automatic memory analysis in `memory_manager.py` has been enhanced to more reliably capture explicit user requests to remember information during a conversation (e.g., "remember that...").